### PR TITLE
bugfix/fix user settings on password update

### DIFF
--- a/lib/price_spotter/accounts.ex
+++ b/lib/price_spotter/accounts.ex
@@ -223,17 +223,15 @@ defmodule PriceSpotter.Accounts do
 
     ## Examples
 
-      iex> maybe_change_user_password(user)
+      iex> maybe_change_user_password(user, %{"password" => "some password"})
       %Ecto.Changeset{data: %User{}}
 
   """
-  def maybe_change_user_password(user, attrs) do
-    if Map.has_key?(attrs, :password) do
-      change_user_password(user, attrs)
-    else
-      Ecto.Changeset.change(user)
-    end
-  end
+  def maybe_change_user_password(user, %{"password" => ""}),
+    do: Ecto.Changeset.change(user)
+
+  def maybe_change_user_password(user, attrs),
+    do: User.password_changeset(user, attrs)
 
   @doc """
   Emulates that the email will change without actually changing

--- a/lib/price_spotter/marketplaces.ex
+++ b/lib/price_spotter/marketplaces.ex
@@ -6,7 +6,7 @@ defmodule PriceSpotter.Marketplaces do
   import Ecto.Query, warn: false
   alias PriceSpotter.Repo
 
-  alias PriceSpotter.Marketplaces.{Product, Supplier}
+  alias PriceSpotter.Marketplaces.{Product, Relations, Supplier}
 
   require Logger
 
@@ -25,6 +25,17 @@ defmodule PriceSpotter.Marketplaces do
 
   def list_products(params) do
     Flop.validate_and_run(Product, params, for: Product)
+  end
+
+  def list_products_by_user(params, user) do
+    from(
+      us in Relations.UserSupplier,
+      where: us.user_id == ^user.id,
+      join: p in Product,
+      on: us.supplier_id == p.supplier_id,
+      select: p
+    )
+    |> Flop.validate_and_run(params, for: Product)
   end
 
   def list_product_categories do

--- a/lib/price_spotter/marketplaces/product.ex
+++ b/lib/price_spotter/marketplaces/product.ex
@@ -76,7 +76,8 @@ defmodule PriceSpotter.Marketplaces.Product do
       :name,
       :price,
       :supplier_url,
-      :price_updated_at
+      :price_updated_at,
+      :supplier_id
     ])
     |> validate_required([
       :category,

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
@@ -14,7 +14,10 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Index do
 
   @impl true
   def handle_params(params, _url, socket) do
-    case Marketplaces.list_products(params) do
+    case Marketplaces.list_products_by_user(
+           params,
+           socket.assigns.current_user
+         ) do
       {:ok, {products, meta}} ->
         {:noreply,
          socket

--- a/test/price_spotter_web/live/admin/marketplaces/product_live_test.exs
+++ b/test/price_spotter_web/live/admin/marketplaces/product_live_test.exs
@@ -1,4 +1,5 @@
 defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLiveTest do
+  alias PriceSpotter.Marketplaces
   use PriceSpotterWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -35,11 +36,23 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLiveTest do
 
   defp create_product(_context) do
     product = product_fixture()
-    %{product: product}
+    %{product: product |> PriceSpotter.Repo.preload(:supplier)}
+  end
+
+  defp assoc_user_product(context) do
+    %{product: product, user: user} = context
+
+    Marketplaces.create_user_supplier(%{
+      user_id: user.id,
+      supplier_id: product.supplier_id,
+      role: :maintainer
+    })
+
+    %{}
   end
 
   describe "Index" do
-    setup [:create_product, :register_and_log_in_admin]
+    setup [:create_product, :register_and_log_in_admin, :assoc_user_product]
 
     test "lists all products", %{conn: conn, product: product} do
       {:ok, _index_live, html} = live(conn, ~p"/admin/marketplaces/products")
@@ -73,6 +86,7 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLiveTest do
       assert html =~ "some category"
     end
 
+    @tag :wip
     test "updates product in listing", %{conn: conn, product: product} do
       {:ok, index_live, _html} = live(conn, ~p"/admin/marketplaces/products")
 


### PR DESCRIPTION
## Fixes

- A bug where the password wasn't being properly changed.

## Description

- Update the `maybe_change_password` function to properly update a user password
- Add supplier to Product changeset cast
- Add a function to filter products by user
- Apply the new function to the products list liveview
