### PR TITLE
feature/add support to handle ean codes

### DIFF
--- a/assets/js/hooks/copy.js
+++ b/assets/js/hooks/copy.js
@@ -1,10 +1,21 @@
 export default {
   mounted() {
     let { to } = this.el.dataset;
-    this.el.addEventListener("click", (ev) => {
-      ev.preventDefault();
+
+    const handleClick = (event) => {
+      event.preventDefault();
       let text = document.getElementById(to).value
       navigator.clipboard.writeText(text).then(() => {})
+    }
+
+    this.el.addEventListener("click", (event) => {
+      handleClick(event)
     });
+
+    this.el.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        handleClick(event)
+      }
+    })
   },
 }

--- a/assets/js/hooks/copy.js
+++ b/assets/js/hooks/copy.js
@@ -1,0 +1,10 @@
+export default {
+  mounted() {
+    let { to } = this.el.dataset;
+    this.el.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      let text = document.getElementById(to).value
+      navigator.clipboard.writeText(text).then(() => {})
+    });
+  },
+}

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -1,5 +1,7 @@
 import LineChart from './line_chart_hook'
+import Copy from './copy'
 
 export default {
+  Copy,
   LineChart
 }

--- a/lib/price_spotter/application.ex
+++ b/lib/price_spotter/application.ex
@@ -28,6 +28,10 @@ defmodule PriceSpotter.Application do
       PriceSpotter.Marketplaces.ProductProducer.child_spec(
         supplier: "maxiconsumo-burzaco",
         module_name: "MaxiconsumoBurzacoProducer"
+      ),
+      PriceSpotter.Marketplaces.ProductProducer.child_spec(
+        supplier: "maxiconsumo-by-ean",
+        module_name: "MaxiconsumoByEanProducer"
       )
     ]
 

--- a/lib/price_spotter/application.ex
+++ b/lib/price_spotter/application.ex
@@ -30,7 +30,7 @@ defmodule PriceSpotter.Application do
         module_name: "MaxiconsumoBurzacoProducer"
       ),
       PriceSpotter.Marketplaces.ProductProducer.child_spec(
-        supplier: "maxiconsumo-by-ean",
+        supplier: "maxiconsumo-burzaco-by-ean",
         module_name: "MaxiconsumoByEanProducer"
       )
     ]

--- a/lib/price_spotter/marketplaces/product.ex
+++ b/lib/price_spotter/marketplaces/product.ex
@@ -16,7 +16,8 @@ defmodule PriceSpotter.Marketplaces.Product do
       :supplier_name,
       :price_updated_since,
       :min_price,
-      :max_price
+      :max_price,
+      :ean
     ],
     sortable: [
       :name,
@@ -24,7 +25,8 @@ defmodule PriceSpotter.Marketplaces.Product do
       :internal_id,
       :supplier_name,
       :price,
-      :price_updated_at
+      :price_updated_at,
+      :ean
     ],
     custom_fields: [
       price_updated_since: [

--- a/lib/price_spotter/marketplaces/product.ex
+++ b/lib/price_spotter/marketplaces/product.ex
@@ -1,6 +1,8 @@
 defmodule PriceSpotter.Marketplaces.Product do
+  alias PriceSpotter.Marketplaces.Product
   use Ecto.Schema
   import Ecto.Changeset
+  import PriceSpotterWeb.Gettext
 
   @max_limit 10_000
   @default_limit 10
@@ -49,6 +51,7 @@ defmodule PriceSpotter.Marketplaces.Product do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "products" do
+    field :ean, :string
     field :category, :string
     field :img_url, :string
     field :internal_id, :string
@@ -68,6 +71,7 @@ defmodule PriceSpotter.Marketplaces.Product do
   def changeset(product, attrs) do
     product
     |> cast(attrs, [
+      :ean,
       :category,
       :img_url,
       :internal_id,
@@ -79,6 +83,7 @@ defmodule PriceSpotter.Marketplaces.Product do
       :price_updated_at,
       :supplier_id
     ])
+    |> maybe_validate_change(:ean, &validate_ean/1)
     |> validate_required([
       :category,
       :img_url,
@@ -102,6 +107,7 @@ defmodule PriceSpotter.Marketplaces.Product do
     changeset(
       %__MODULE__{},
       Map.merge(product, %{
+        "ean" => product["ean_code"],
         "supplier_name" => product["supplier"],
         "meta" => Jason.decode!(product["meta"]),
         "price" => sanitize_price(product["price"])
@@ -121,6 +127,27 @@ defmodule PriceSpotter.Marketplaces.Product do
   defp sanitize_price("unpriced"), do: 0
 
   defp sanitize_price(price), do: price
+
+  defp maybe_validate_change(changeset, field, validate_fn) do
+    case get_change(changeset, field) do
+      nil ->
+        changeset
+
+      _change ->
+        validate_fn.(changeset)
+    end
+  end
+
+  @spec validate_ean(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp validate_ean(changeset) do
+    validate_length(changeset, :ean, min: 13, max: 14)
+    |> then(fn changeset ->
+      changeset
+      |> validate_format(:ean, ~r/^\d+$/,
+        message: gettext("must be numbers only")
+      )
+    end)
+  end
 end
 
 defmodule PriceSpotter.Marketplaces.Product.CustomFilters do

--- a/lib/price_spotter/marketplaces/product.ex
+++ b/lib/price_spotter/marketplaces/product.ex
@@ -87,7 +87,6 @@ defmodule PriceSpotter.Marketplaces.Product do
     ])
     |> maybe_validate_change(:ean, &validate_ean/1)
     |> validate_required([
-      :category,
       :img_url,
       :internal_id,
       :supplier_name,

--- a/lib/price_spotter_web.ex
+++ b/lib/price_spotter_web.ex
@@ -110,6 +110,7 @@ defmodule PriceSpotterWeb do
       import Phoenix.HTML
       # Core UI components and translation
       import PriceSpotterWeb.CoreComponents
+      import PriceSpotterWeb.CustomComponents
       import PriceSpotterWeb.Gettext
 
       # Shortcut for generating JS commands

--- a/lib/price_spotter_web/components/core_components.ex
+++ b/lib/price_spotter_web/components/core_components.ex
@@ -738,13 +738,32 @@ defmodule PriceSpotterWeb.CoreComponents do
     >
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
         <Flop.Phoenix.filter_fields :let={i} form={@form} fields={@fields}>
-          <.input
-            field={i.field}
-            label={i.label}
-            type={i.type}
-            phx-debounce={120}
-            {i.rest}
-          />
+          <%= if i.rest[:new_feature] do %>
+            <div class="relative">
+              <div class="absolute top-0 right-0">
+                <.pill
+                  text={gettext("New")}
+                  color="bg-red-500 dark:bg-red-500"
+                  text_color="text-white dark:text-white"
+                />
+              </div>
+              <.input
+                field={i.field}
+                label={i.label}
+                type={i.type}
+                phx-debounce={120}
+                {i.rest}
+              />
+            </div>
+          <% else %>
+            <.input
+              field={i.field}
+              label={i.label}
+              type={i.type}
+              phx-debounce={120}
+              {i.rest}
+            />
+          <% end %>
         </Flop.Phoenix.filter_fields>
       </div>
 
@@ -792,6 +811,21 @@ defmodule PriceSpotterWeb.CoreComponents do
       >
         <%= render_slot(@inner_block, assigns) %>
       </div>
+    </div>
+    """
+  end
+
+  attr :text, :string, required: true
+  attr :color, :string, default: "bg-white"
+  attr :text_color, :string, default: "text-black"
+
+  def pill(assigns) do
+    ~H"""
+    <div class={"
+      rounded-md #{@color} px-2 text-xs cursor-default border-[1px] shadow-md
+      bg-gradient-to-r from-red-500 to-teal-500 rounded-lg opacity-75 transition duration-500
+    "}>
+      <span class={"#{@text_color} animate-pulse"}><%= @text %></span>
     </div>
     """
   end

--- a/lib/price_spotter_web/components/core_components.ex
+++ b/lib/price_spotter_web/components/core_components.ex
@@ -244,7 +244,7 @@ defmodule PriceSpotterWeb.CoreComponents do
   def simple_form(assigns) do
     ~H"""
     <.form :let={f} for={@for} as={@as} {@rest}>
-      <div class="mt-10 space-y-8 bg-gray-100">
+      <div class="mt-10 space-y-8">
         <%= render_slot(@inner_block, f) %>
         <div
           :for={action <- @actions}

--- a/lib/price_spotter_web/components/custom_components.ex
+++ b/lib/price_spotter_web/components/custom_components.ex
@@ -1,0 +1,19 @@
+defmodule PriceSpotterWeb.CustomComponents do
+  @moduledoc false
+
+  use Phoenix.Component
+
+  attr :has_code, :boolean, required: true
+  attr :ean, :string, required: true
+
+  def render_ean(assigns) do
+    ~H"""
+    <span class={"
+        text-md font-medium md:block text-center self-center
+        #{if @has_code, do: "text-teal-500", else: "text-yellow-500"}
+      "}>
+      <%= @ean %>
+    </span>
+    """
+  end
+end

--- a/lib/price_spotter_web/components/custom_components.ex
+++ b/lib/price_spotter_web/components/custom_components.ex
@@ -9,8 +9,9 @@ defmodule PriceSpotterWeb.CustomComponents do
   def render_ean(assigns) do
     ~H"""
     <span class={"
-        text-md font-medium md:block text-center self-center
-        #{if @has_code, do: "text-teal-500", else: "text-yellow-500"}
+        text-sm font-medium md:block text-center self-center bg-gray-100
+        rounded-md px-2 shadow-inner-lg border-2 border-gray-200
+        #{if @has_code, do: "text-gray-500", else: "text-yellow-500"}
       "}>
       <%= @ean %>
     </span>

--- a/lib/price_spotter_web/components/custom_components.ex
+++ b/lib/price_spotter_web/components/custom_components.ex
@@ -11,7 +11,7 @@ defmodule PriceSpotterWeb.CustomComponents do
     <span class={"
         text-sm font-medium md:block text-center self-center bg-gray-100
         rounded-md px-2 shadow-inner-lg border-2 border-gray-200
-        #{if @has_code, do: "text-gray-500", else: "text-yellow-500"}
+        #{if @has_code, do: "text-blue-500", else: "text-yellow-500"}
       "}>
       <%= @ean %>
     </span>

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex
@@ -23,6 +23,7 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.FormComponent do
       >
         <.input field={@form[:category]} type="text" label={gettext("Category")} />
         <.input field={@form[:img_url]} type="text" label={gettext("Img url")} />
+        <.input field={@form[:ean]} type="number" label={gettext("EAN")} />
         <.input
           field={@form[:internal_id]}
           type="text"

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
@@ -107,6 +107,17 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Index do
     """
   end
 
+  @spec maybe_render_category(String.t() | nil) :: String.t()
+  def maybe_render_category(category) do
+    case category do
+      nil ->
+        gettext("Unassigned")
+
+      category ->
+        String.replace(category, "-", " ")
+    end
+  end
+
   defp assign_selection_options(socket) do
     socket
     |> assign(:product_categories, Marketplaces.list_product_categories())

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
@@ -123,6 +123,13 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Index do
         op: :ilike,
         placeholder: gettext("Filter by product name")
       ],
+      ean: [
+        label: gettext("Ean"),
+        op: :ilike,
+        placeholder: gettext("Search by EAN"),
+        type: "number",
+        new_feature: true
+      ],
       category: [
         label: gettext("Category"),
         type: "select",
@@ -163,6 +170,7 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Index do
   defp get_columns,
     do: [
       %{name: :name, label: gettext("Product")},
+      %{name: :ean, label: gettext("Ean")},
       %{name: :price, label: gettext("Price")},
       %{name: :price_updated_at, label: gettext("Last Price Update")},
       %{name: :supplier_name, label: gettext("Supplier")},

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex
@@ -124,7 +124,7 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Index do
         placeholder: gettext("Filter by product name")
       ],
       ean: [
-        label: gettext("Ean"),
+        label: gettext("EAN"),
         op: :ilike,
         placeholder: gettext("Search by EAN"),
         type: "number",
@@ -170,7 +170,7 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Index do
   defp get_columns,
     do: [
       %{name: :name, label: gettext("Product")},
-      %{name: :ean, label: gettext("Ean")},
+      %{name: :ean, label: gettext("EAN")},
       %{name: :price, label: gettext("Price")},
       %{name: :price_updated_at, label: gettext("Last Price Update")},
       %{name: :supplier_name, label: gettext("Supplier")},

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex
@@ -163,9 +163,15 @@
           tbody_td_attrs={[class: "text-xs sm:text-base"]}
         >
           <div class="flex justify-center">
-            <div class="flex bg-green-200 rounded-lg text-center font-medium w-fit px-1">
+            <div class="
+              text-sm flex bg-green-200 rounded-lg text-center font-medium w-fit px-1
+              shadow-inner-lg border-[1px] border-green-300
+              text-gray-700
+            ">
               <%!-- <.icon name="hero-currency-dollar-solid" class="self-center h-5 w-5 opacity-60 text-zinc-600" /> --%>
-              <span class="self-center">$<%= product.price %></span>
+              <span class="self-center">
+                $<%= product.price %>
+              </span>
             </div>
           </div>
         </:col>
@@ -174,9 +180,8 @@
           label={gettext("Last Update")}
           field={:price_updated_at}
           col_style="width: 20%;"
-          attrs={[class: ""]}
         >
-          <div class="text-center text-sm italic">
+          <div class="text-center text-xs italic">
             <%= TimeAgo.time_ago(product.price_updated_at) %>
           </div>
         </:col>
@@ -187,7 +192,7 @@
           col_style="width: 15%;"
         >
           <div class="flex text-xs justify-center text-center">
-            <span class="bg-red-100 rounded-md px-1">
+            <span class="bg-red-100 rounded-md px-1 shadow-inner-lg border-[1px] border-red-200">
               <%= String.replace(product.supplier_name, "-", " ") %>
             </span>
           </div>
@@ -199,7 +204,7 @@
           col_style="width: 20%;"
         >
           <div class="flex text-xs justify-center text-center">
-            <span class="bg-blue-100 rounded-md px-1">
+            <span class="bg-blue-100 rounded-md px-1 shadow-inner-lg border-[1px] border-blue-200">
               <%= String.replace(product.category, "-", " ") %>
             </span>
           </div>

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex
@@ -205,7 +205,7 @@
         >
           <div class="flex text-xs justify-center text-center">
             <span class="bg-blue-100 rounded-md px-1 shadow-inner-lg border-[1px] border-blue-200">
-              <%= String.replace(product.category, "-", " ") %>
+              <%= maybe_render_category(product.category) %>
             </span>
           </div>
         </:col>

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex
@@ -15,7 +15,13 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Show do
 
     {:ok,
      socket
+     |> assign(:copy_clicked, false)
      |> assign_interval()}
+  end
+
+  @impl true
+  def handle_event("copy_ean", _params, socket) do
+    {:noreply, assign(socket, :copy_clicked, true)}
   end
 
   @impl true
@@ -153,6 +159,22 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Show do
   #
 
   defp render_price(price), do: "$#{price}"
+
+  @spec format_ean_string(nil | String.t()) :: String.t()
+  defp format_ean_string(nil), do: gettext("Unassigned")
+
+  defp format_ean_string(ean) do
+    if String.length(ean) === 13 do
+      {country_code, rest} = String.split_at(ean, 2)
+      {manufacturer_code, rest} = String.split_at(rest, 5)
+      {product_code, rest} = String.split_at(rest, 5)
+      {check_digit, ""} = String.split_at(rest, 1)
+
+      "#{country_code} #{manufacturer_code} #{product_code} #{check_digit}"
+    else
+      ean
+    end
+  end
 
   # ----------------------------------------------------------------------------
   # Assignment functions

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex
@@ -29,6 +29,13 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Show do
   end
 
   @impl true
+  def handle_event("delete", _params, socket) do
+    {:ok, _} = Marketplaces.delete_product(socket.assigns.product)
+
+    {:noreply, push_navigate(socket, to: ~p"/admin/marketplaces/products")}
+  end
+
+  @impl true
   def handle_params(%{"id" => id}, _uri, socket) do
     {:noreply,
      socket
@@ -82,13 +89,6 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Show do
            gettext("There was an error loading the price chart")
          )}
     end
-  end
-
-  @impl true
-  def handle_event("delete", _params, socket) do
-    {:ok, _} = Marketplaces.delete_product(socket.assigns.product)
-
-    {:noreply, push_navigate(socket, to: ~p"/admin/marketplaces/products")}
   end
 
   defp page_title(:show), do: gettext("Show Product")

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex
@@ -176,6 +176,17 @@ defmodule PriceSpotterWeb.Admin.Marketplaces.ProductLive.Show do
     end
   end
 
+  @spec maybe_render_category(String.t() | nil) :: String.t()
+  def maybe_render_category(category) do
+    case category do
+      nil ->
+        gettext("Unassigned")
+
+      category ->
+        String.replace(category, "-", " ")
+    end
+  end
+
   # ----------------------------------------------------------------------------
   # Assignment functions
   #

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
@@ -93,6 +93,43 @@
             </div>
           </span>
         </li>
+        <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400 justify-between">
+          <div>
+            <span class="font-medium w-1/2 md:w-1/3">
+              <%= gettext("EAN") %>
+            </span>
+          </div>
+          <div id="ean-code">
+            <.render_ean
+              ean={format_ean_string(@product.ean)}
+              has_code={@product.ean !== nil}
+            />
+            <input id="#ean_code" type="hidden" value={@product.ean} />
+          </div>
+          <%= if @product.ean do %>
+            <div>
+              <span
+                tabindex="0"
+                id="copy-ean-code"
+                data-to="#ean_code"
+                phx-hook="Copy"
+                phx-click="copy_ean"
+              >
+                <%= if @copy_clicked do %>
+                  <.icon
+                    name="hero-clipboard-document-check"
+                    class="text-teal-500 dark:teal-gray-500 h-5 w-5"
+                  />
+                <% else %>
+                  <.icon
+                    name="hero-clipboard-document"
+                    class="text-gray-900 dark:text-gray-100 h-5 w-5 hover:text-blue-500"
+                  />
+                <% end %>
+              </span>
+            </div>
+          <% end %>
+        </li>
         <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400">
           <a
             href={@product.supplier_url}

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
@@ -43,13 +43,13 @@
     id={"products-#{@product.id}-card"}
   >
     <div class="flex items-center justify-between">
-      <div class="text-left">
+      <div class="text-left w-full">
         <h2 class="text-gray-900 dark:text-gray-100 text-lg font-bold border-b border-orange-500">
           <%= @product.name %>
         </h2>
         <h3 class="mt-2 text-xl font-bold text-orange-500 text-left cursor-text">
         </h3>
-        <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400 items-center justify-between">
+        <li class="flex border-0 py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 items-center justify-between">
           <div class="md:w-1/3 grid place-items-center">
             <img src={@product.img_url} class="rounded-lg" />
           </div>
@@ -73,8 +73,8 @@
             </div>
           </div>
         </li>
-        <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400 items-center">
-          <span class="font-medium w-1/2 md:w-1/3">
+        <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-between">
+          <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3">
             <%= gettext("Supplier") %>
           </span>
           <span class="">
@@ -83,8 +83,8 @@
             </div>
           </span>
         </li>
-        <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400 items-center">
-          <span class="font-medium w-1/2 md:w-1/3">
+        <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-between">
+          <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3">
             <%= gettext("Category") %>
           </span>
           <span class="">
@@ -93,9 +93,9 @@
             </div>
           </span>
         </li>
-        <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400 justify-between">
+        <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-between">
           <div>
-            <span class="font-medium w-1/2 md:w-1/3">
+            <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3">
               <%= gettext("EAN") %>
             </span>
           </div>
@@ -114,11 +114,13 @@
                 data-to="#ean_code"
                 phx-hook="Copy"
                 phx-click="copy_ean"
+                phx-window-keydown="copy_ean"
+                phx-key="enter"
               >
                 <%= if @copy_clicked do %>
                   <.icon
                     name="hero-clipboard-document-check"
-                    class="text-teal-500 dark:teal-gray-500 h-5 w-5"
+                    class="text-teal-500 dark:text-teal-500 h-5 w-5"
                   />
                 <% else %>
                   <.icon
@@ -130,21 +132,21 @@
             </div>
           <% end %>
         </li>
-        <li class="flex border-b py-1 border-b-zinc-600 dark:border-b-zinc-400">
+        <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-end">
           <a
             href={@product.supplier_url}
             target="_blank"
-            class="hover:text-sky-500 hover:opacity-100"
+            class="hover:text-sky-500 hover:opacity-100 text-gray-600 dark:text-gray-400 italic text-sm"
           >
-            <.icon name="hero-link-solid" class="h-5 w-5 opacity-60" />
-            <span>
+            <.icon name="hero-link-solid" class="h-4 w-4 opacity-60" />
+            <span class="">
               <%= gettext("External link") %>
             </span>
           </a>
         </li>
       </div>
     </div>
-    <div class="my-4">
+    <div class="my-4 flex justify-end">
       <p class="text-sm italic text-gray-600 dark:text-gray-400 text-left">
         <%= gettext("Last price") %>: <%= TimeAgo.time_ago(
           @product.price_updated_at

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
@@ -89,7 +89,7 @@
           </span>
           <span class="">
             <div class="bg-blue-200 border-[1px] border-blue-100 px-3 py-1 rounded-full text-xs font-medium text-gray-500 md:block text-center shadow-inner-lg">
-              <%= String.replace(@product.category, "-", " ") %>
+              <%= maybe_render_category(@product.category) %>
             </div>
           </span>
         </li>
@@ -125,7 +125,7 @@
                 <% else %>
                   <.icon
                     name="hero-clipboard-document"
-                    class="text-gray-900 dark:text-gray-100 h-5 w-5 hover:text-blue-500"
+                    class="text-gray-500 dark:text-gray-500 h-5 w-5 hover:text-blue-500"
                   />
                 <% end %>
               </span>

--- a/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
+++ b/lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex
@@ -74,28 +74,28 @@
           </div>
         </li>
         <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-between">
-          <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3">
+          <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3 self-center">
             <%= gettext("Supplier") %>
           </span>
           <span class="">
-            <div class="bg-red-200 px-3 py-1 rounded-full text-xs font-medium text-gray-800 md:block text-center">
+            <div class="bg-red-200 border-[1px] border-red-100 px-3 py-1 rounded-full text-xs font-medium text-gray-800 md:block text-center shadow-inner-lg">
               <%= String.replace(@product.supplier_name, "-", " ") %>
             </div>
           </span>
         </li>
         <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-between">
-          <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3">
+          <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3 self-center">
             <%= gettext("Category") %>
           </span>
           <span class="">
-            <div class="bg-blue-200 px-3 py-1 rounded-full text-xs font-medium text-gray-500 md:block text-center">
+            <div class="bg-blue-200 border-[1px] border-blue-100 px-3 py-1 rounded-full text-xs font-medium text-gray-500 md:block text-center shadow-inner-lg">
               <%= String.replace(@product.category, "-", " ") %>
             </div>
           </span>
         </li>
         <li class="flex border-b py-1 border-dashed border-b-zinc-200 dark:border-b-zinc-700 justify-between">
           <div>
-            <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3">
+            <span class="text-gray-600 dark:text-gray-400 font-medium w-1/2 md:w-1/3 self-center">
               <%= gettext("EAN") %>
             </span>
           </div>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -62,14 +62,14 @@ msgstr[1] ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:24
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:169
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:134
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:177
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:197
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:88
 #, elixir-autogen, elixir-format
@@ -77,13 +77,13 @@ msgid "Category"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:73
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:96
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:101
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Edit Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:110
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Img url"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:118
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr ""
@@ -124,13 +124,13 @@ msgid "New Product"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:41
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:166
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:174
 #, elixir-autogen, elixir-format
 msgid "Price"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:122
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:165
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:172
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Product"
@@ -159,13 +159,13 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:100
 #, elixir-autogen, elixir-format
 msgid "Show Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:133
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:168
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:140
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:176
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:185
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:78
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:2
@@ -235,12 +235,12 @@ msgstr ""
 msgid "less than a minute ago"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:136
 #, elixir-autogen, elixir-format
 msgid "All categories"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:135
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "All suppliers"
 msgstr ""
@@ -250,33 +250,33 @@ msgstr ""
 msgid "Last Price"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:139
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:146
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Last Update"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:150
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "Max Price"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:144
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Min Price"
 msgstr ""
 
-#: lib/price_spotter_web/components/core_components.ex:758
+#: lib/price_spotter_web/components/core_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "Clear Filters"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:152
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:159
 #, elixir-autogen, elixir-format
 msgid "Choose a maximum price"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:146
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:153
 #, elixir-autogen, elixir-format
 msgid "Choose a minimum price"
 msgstr ""
@@ -297,17 +297,17 @@ msgstr ""
 msgid "Filter by product name"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:170
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:178
 #, elixir-autogen, elixir-format
 msgid "Image URL"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:167
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:175
 #, elixir-autogen, elixir-format
 msgid "Last Price Update"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:171
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgid "Product URL"
 msgstr ""
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Wholesaler products and prices"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:90
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the price chart"
 msgstr ""
@@ -909,33 +909,49 @@ msgstr ""
 msgid "Export all pages?"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:135
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:159
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:147
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:98
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "EAN"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:161
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/price_spotter/marketplaces/product.ex:147
+#: lib/price_spotter/marketplaces/product.ex:149
 #, elixir-autogen, elixir-format
 msgid "must be numbers only"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
+#, elixir-autogen, elixir-format
+msgid "Ean"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
+#, elixir-autogen, elixir-format
+msgid "Search by EAN"
+msgstr ""
+
+#: lib/price_spotter_web/components/core_components.ex:746
+#, elixir-autogen, elixir-format
+msgid "New"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -62,7 +62,7 @@ msgstr[1] ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:199
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Edit Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:141
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Img url"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:149
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr ""
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Min Price"
 msgstr ""
 
-#: lib/price_spotter_web/components/core_components.ex:778
+#: lib/price_spotter_web/components/core_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "Clear Filters"
 msgstr ""
@@ -909,22 +909,24 @@ msgstr ""
 msgid "Export all pages?"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:166
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:190
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:178
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "EAN"
@@ -940,18 +942,12 @@ msgstr ""
 msgid "must be numbers only"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
-#, elixir-autogen, elixir-format
-msgid "Ean"
-msgstr ""
-
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
 #, elixir-autogen, elixir-format
 msgid "Search by EAN"
 msgstr ""
 
-#: lib/price_spotter_web/components/core_components.ex:746
+#: lib/price_spotter_web/components/core_components.ex:745
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -62,7 +62,7 @@ msgstr[1] ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:163
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr ""
@@ -71,19 +71,19 @@ msgstr ""
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:169
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:197
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:89
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:73
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:96
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Edit Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:105
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Img url"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:113
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr ""
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Listing Products"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:36
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:37
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/form_component.ex:24
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/index.html.heex:19
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:17
@@ -123,7 +123,7 @@ msgstr ""
 msgid "New Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:40
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:41
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:166
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -136,30 +136,30 @@ msgstr ""
 msgid "Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:104
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:105
 #, elixir-autogen, elixir-format
 msgid "Product created successfully"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:89
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Product updated successfully"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:50
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Save Product"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/accounts/user_live/form_component.ex:34
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:49
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:50
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/form_component.ex:26
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/form_component.ex:53
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:94
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "Show Product"
 msgstr ""
@@ -167,7 +167,7 @@ msgstr ""
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:133
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:168
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:185
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:79
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:78
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:2
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/form_component.ex:48
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/index.html.heex:19
@@ -175,12 +175,12 @@ msgstr ""
 msgid "Supplier"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:34
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Supplier name"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:46
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "Supplier url"
 msgstr ""
@@ -200,7 +200,7 @@ msgstr ""
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:29
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:30
 #, elixir-autogen, elixir-format
 msgid "Internal id"
 msgstr ""
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Wholesaler products and prices"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:82
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:90
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the price chart"
 msgstr ""
@@ -909,17 +909,33 @@ msgstr ""
 msgid "Export all pages?"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:130
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:154
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:142
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Weekly"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:98
+#, elixir-autogen, elixir-format
+msgid "EAN"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:161
+#, elixir-autogen, elixir-format
+msgid "Unassigned"
+msgstr ""
+
+#: lib/price_spotter/marketplaces/product.ex:147
+#, elixir-autogen, elixir-format
+msgid "must be numbers only"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -62,7 +62,7 @@ msgstr[1] ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:199
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Edit Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:141
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Img url"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:149
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr ""
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Min Price"
 msgstr ""
 
-#: lib/price_spotter_web/components/core_components.ex:778
+#: lib/price_spotter_web/components/core_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "Clear Filters"
 msgstr ""
@@ -909,22 +909,24 @@ msgstr "Edit supplier access"
 msgid "Export all pages?"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:166
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:190
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:178
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "EAN"
@@ -940,18 +942,12 @@ msgstr ""
 msgid "must be numbers only"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
-#, elixir-autogen, elixir-format
-msgid "Ean"
-msgstr ""
-
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
 #, elixir-autogen, elixir-format
 msgid "Search by EAN"
 msgstr ""
 
-#: lib/price_spotter_web/components/core_components.ex:746
+#: lib/price_spotter_web/components/core_components.ex:745
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -62,7 +62,7 @@ msgstr[1] ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:163
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr ""
@@ -71,19 +71,19 @@ msgstr ""
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:169
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:197
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:89
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:73
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:96
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Edit Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:105
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Img url"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:113
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr ""
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Listing Products"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:36
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:37
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/form_component.ex:24
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/index.html.heex:19
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:17
@@ -123,7 +123,7 @@ msgstr ""
 msgid "New Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:40
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:41
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:166
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -136,30 +136,30 @@ msgstr ""
 msgid "Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:104
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:105
 #, elixir-autogen, elixir-format
 msgid "Product created successfully"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:89
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Product updated successfully"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:50
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Save Product"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/accounts/user_live/form_component.ex:34
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:49
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:50
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/form_component.ex:26
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/form_component.ex:53
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:94
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "Show Product"
 msgstr ""
@@ -167,7 +167,7 @@ msgstr ""
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:133
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:168
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:185
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:79
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:78
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:2
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/form_component.ex:48
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/index.html.heex:19
@@ -175,12 +175,12 @@ msgstr ""
 msgid "Supplier"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:34
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Supplier name"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:46
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "Supplier url"
 msgstr ""
@@ -200,7 +200,7 @@ msgstr ""
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:29
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:30
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Internal id"
 msgstr ""
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Wholesaler products and prices"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:82
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:90
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the price chart"
 msgstr ""
@@ -909,17 +909,33 @@ msgstr "Edit supplier access"
 msgid "Export all pages?"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:130
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:154
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:142
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Weekly"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:98
+#, elixir-autogen, elixir-format
+msgid "EAN"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:161
+#, elixir-autogen, elixir-format
+msgid "Unassigned"
+msgstr ""
+
+#: lib/price_spotter/marketplaces/product.ex:147
+#, elixir-autogen, elixir-format
+msgid "must be numbers only"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -62,14 +62,14 @@ msgstr[1] ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:24
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:169
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:134
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:177
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:197
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:88
 #, elixir-autogen, elixir-format
@@ -77,13 +77,13 @@ msgid "Category"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:73
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:96
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:101
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Edit Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:110
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Img url"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:118
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr ""
@@ -124,13 +124,13 @@ msgid "New Product"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:41
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:166
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:174
 #, elixir-autogen, elixir-format
 msgid "Price"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:122
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:165
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:172
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Product"
@@ -159,13 +159,13 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:100
 #, elixir-autogen, elixir-format
 msgid "Show Product"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:133
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:168
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:140
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:176
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:185
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:78
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:2
@@ -235,12 +235,12 @@ msgstr ""
 msgid "less than a minute ago"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:136
 #, elixir-autogen, elixir-format
 msgid "All categories"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:135
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "All suppliers"
 msgstr ""
@@ -250,33 +250,33 @@ msgstr ""
 msgid "Last Price"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:139
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:146
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Last Update"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:150
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Max Price"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:144
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Min Price"
 msgstr ""
 
-#: lib/price_spotter_web/components/core_components.ex:758
+#: lib/price_spotter_web/components/core_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "Clear Filters"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:152
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:159
 #, elixir-autogen, elixir-format
 msgid "Choose a maximum price"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:146
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:153
 #, elixir-autogen, elixir-format
 msgid "Choose a minimum price"
 msgstr ""
@@ -297,17 +297,17 @@ msgstr ""
 msgid "Filter by product name"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:170
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:178
 #, elixir-autogen, elixir-format
 msgid "Image URL"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:167
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Price Update"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:171
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:179
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Product URL"
 msgstr ""
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Wholesaler products and prices"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:90
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the price chart"
 msgstr ""
@@ -909,33 +909,49 @@ msgstr "Edit supplier access"
 msgid "Export all pages?"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:135
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:159
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:147
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr ""
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:98
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "EAN"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:161
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/price_spotter/marketplaces/product.ex:147
+#: lib/price_spotter/marketplaces/product.ex:149
 #, elixir-autogen, elixir-format
 msgid "must be numbers only"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
+#, elixir-autogen, elixir-format
+msgid "Ean"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
+#, elixir-autogen, elixir-format
+msgid "Search by EAN"
+msgstr ""
+
+#: lib/price_spotter_web/components/core_components.ex:746
+#, elixir-autogen, elixir-format
+msgid "New"
 msgstr ""

--- a/priv/gettext/es_AR/LC_MESSAGES/default.po
+++ b/priv/gettext/es_AR/LC_MESSAGES/default.po
@@ -62,7 +62,7 @@ msgstr[1] "Hace %{years} años"
 msgid "Attempting to reconnect"
 msgstr "Intentando reconectar"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:163
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr "Volver a productos"
@@ -71,19 +71,19 @@ msgstr "Volver a productos"
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:169
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:197
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:89
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Categoría"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:73
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:96
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Edit Product"
 msgstr "Actualizar producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:105
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr "Enlace externo"
@@ -98,7 +98,7 @@ msgstr "Inicio"
 msgid "Img url"
 msgstr "URL de imagen"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:113
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr "Ultimo Precio"
@@ -109,7 +109,7 @@ msgstr "Ultimo Precio"
 msgid "Listing Products"
 msgstr "Lista de productos"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:36
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:37
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/form_component.ex:24
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/index.html.heex:19
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:17
@@ -123,7 +123,7 @@ msgstr "Nombre"
 msgid "New Product"
 msgstr "Nuevo Producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:40
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:41
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:166
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -136,30 +136,30 @@ msgstr "Precio"
 msgid "Product"
 msgstr "Producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:104
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:105
 #, elixir-autogen, elixir-format
 msgid "Product created successfully"
 msgstr "Producto creado"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:89
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Product updated successfully"
 msgstr "Producto Actualizado"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:50
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Save Product"
 msgstr "Guardar"
 
 #: lib/price_spotter_web/live/admin/accounts/user_live/form_component.ex:34
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:49
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:50
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/form_component.ex:26
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/form_component.ex:53
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:94
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "Show Product"
 msgstr "Detalle de Producto"
@@ -167,7 +167,7 @@ msgstr "Detalle de Producto"
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:133
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:168
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:185
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:79
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:78
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:2
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/form_component.ex:48
 #: lib/price_spotter_web/live/admin/marketplaces/user_supplier_live/index.html.heex:19
@@ -175,12 +175,12 @@ msgstr "Detalle de Producto"
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:34
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Supplier name"
 msgstr "Nombre de proveedor"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:46
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "Supplier url"
 msgstr "Web en proveedor"
@@ -200,7 +200,7 @@ msgstr "Utiliza este formulario para administrar los registros de la base."
 msgid "We can't find the internet"
 msgstr "Sin conexión a internet"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:29
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:30
 #, elixir-autogen, elixir-format
 msgid "Internal id"
 msgstr "ID interno"
@@ -604,7 +604,7 @@ msgstr "Busca, filtra y exporta a planillas de calculo los productos y precios d
 msgid "Wholesaler products and prices"
 msgstr "Productos y precios mayoristas"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:82
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:90
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the price chart"
 msgstr "Ocurrió un error cargando el gráfico de precios"
@@ -909,17 +909,33 @@ msgstr "Editar Acceso a proveedor"
 msgid "Export all pages?"
 msgstr "¿Exportar todas las páginas?"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:130
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Diario"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:154
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "Mes"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:142
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr "Semanal"
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:98
+#, elixir-autogen, elixir-format
+msgid "EAN"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:161
+#, elixir-autogen, elixir-format
+msgid "Unassigned"
+msgstr "No asignado"
+
+#: lib/price_spotter/marketplaces/product.ex:147
+#, elixir-autogen, elixir-format
+msgid "must be numbers only"
+msgstr "debe contener número únicamente"

--- a/priv/gettext/es_AR/LC_MESSAGES/default.po
+++ b/priv/gettext/es_AR/LC_MESSAGES/default.po
@@ -62,7 +62,7 @@ msgstr[1] "Hace %{years} años"
 msgid "Attempting to reconnect"
 msgstr "Intentando reconectar"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:199
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr "Volver a productos"
@@ -83,7 +83,7 @@ msgstr "Categoría"
 msgid "Edit Product"
 msgstr "Actualizar producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:141
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr "Enlace externo"
@@ -98,7 +98,7 @@ msgstr "Inicio"
 msgid "Img url"
 msgstr "URL de imagen"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:149
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr "Ultimo Precio"
@@ -266,7 +266,7 @@ msgstr "Hasta $"
 msgid "Min Price"
 msgstr "Desde $"
 
-#: lib/price_spotter_web/components/core_components.ex:778
+#: lib/price_spotter_web/components/core_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "Clear Filters"
 msgstr "Resetear Filtros"
@@ -909,26 +909,28 @@ msgstr "Editar Acceso a proveedor"
 msgid "Export all pages?"
 msgstr "¿Exportar todas las páginas?"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:166
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Diario"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:190
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "Mes"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:178
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr "Semanal"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "EAN"
-msgstr ""
+msgstr "EAN"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:164
 #, elixir-autogen, elixir-format
@@ -940,18 +942,12 @@ msgstr "No asignado"
 msgid "must be numbers only"
 msgstr "debe contener número únicamente"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
-#, elixir-autogen, elixir-format
-msgid "Ean"
-msgstr ""
-
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
 #, elixir-autogen, elixir-format
 msgid "Search by EAN"
 msgstr "Búsqueda por EAN"
 
-#: lib/price_spotter_web/components/core_components.ex:746
+#: lib/price_spotter_web/components/core_components.ex:745
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Nuevo"

--- a/priv/gettext/es_AR/LC_MESSAGES/default.po
+++ b/priv/gettext/es_AR/LC_MESSAGES/default.po
@@ -62,14 +62,14 @@ msgstr[1] "Hace %{years} años"
 msgid "Attempting to reconnect"
 msgstr "Intentando reconectar"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:168
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Back to products"
 msgstr "Volver a productos"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:24
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:169
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:134
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:177
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:197
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:88
 #, elixir-autogen, elixir-format
@@ -77,13 +77,13 @@ msgid "Category"
 msgstr "Categoría"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:73
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:96
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:101
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Edit Product"
 msgstr "Actualizar producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:110
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr "Enlace externo"
@@ -98,7 +98,7 @@ msgstr "Inicio"
 msgid "Img url"
 msgstr "URL de imagen"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:118
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Last price"
 msgstr "Ultimo Precio"
@@ -124,13 +124,13 @@ msgid "New Product"
 msgstr "Nuevo Producto"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:41
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:166
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:174
 #, elixir-autogen, elixir-format
 msgid "Price"
 msgstr "Precio"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:122
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:165
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:172
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Product"
@@ -159,13 +159,13 @@ msgstr "Guardar"
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:100
 #, elixir-autogen, elixir-format
 msgid "Show Product"
 msgstr "Detalle de Producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:133
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:168
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:140
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:176
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:185
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:78
 #: lib/price_spotter_web/live/admin/marketplaces/supplier_live/show.html.heex:2
@@ -235,12 +235,12 @@ msgstr "Recién"
 msgid "less than a minute ago"
 msgstr "Hace menos de un minuto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:136
 #, elixir-autogen, elixir-format
 msgid "All categories"
 msgstr "Todas las categorías"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:135
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "All suppliers"
 msgstr "Todos los proveedores"
@@ -250,33 +250,33 @@ msgstr "Todos los proveedores"
 msgid "Last Price"
 msgstr "Ultimo Precio"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:139
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:146
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Last Update"
 msgstr "Ultima Actualización"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:150
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "Max Price"
 msgstr "Hasta $"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:144
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Min Price"
 msgstr "Desde $"
 
-#: lib/price_spotter_web/components/core_components.ex:758
+#: lib/price_spotter_web/components/core_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "Clear Filters"
 msgstr "Resetear Filtros"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:152
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:159
 #, elixir-autogen, elixir-format
 msgid "Choose a maximum price"
 msgstr "Elegí un precio máximo"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:146
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:153
 #, elixir-autogen, elixir-format
 msgid "Choose a minimum price"
 msgstr "Elegí un precio mínimo"
@@ -297,17 +297,17 @@ msgstr "Exportar"
 msgid "Filter by product name"
 msgstr "Filtro por nombre de producto"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:170
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:178
 #, elixir-autogen, elixir-format
 msgid "Image URL"
 msgstr "URL de imagen"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:167
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:175
 #, elixir-autogen, elixir-format
 msgid "Last Price Update"
 msgstr "Ultima actualización"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:171
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgid "Product URL"
 msgstr "Producto"
@@ -604,7 +604,7 @@ msgstr "Busca, filtra y exporta a planillas de calculo los productos y precios d
 msgid "Wholesaler products and prices"
 msgstr "Productos y precios mayoristas"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:90
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the price chart"
 msgstr "Ocurrió un error cargando el gráfico de precios"
@@ -909,33 +909,49 @@ msgstr "Editar Acceso a proveedor"
 msgid "Export all pages?"
 msgstr "¿Exportar todas las páginas?"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:135
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Diario"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:159
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "Mes"
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:147
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Weekly"
 msgstr "Semanal"
 
 #: lib/price_spotter_web/live/admin/marketplaces/product_live/form_component.ex:26
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:98
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "EAN"
 msgstr ""
 
-#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:161
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "No asignado"
 
-#: lib/price_spotter/marketplaces/product.ex:147
+#: lib/price_spotter/marketplaces/product.ex:149
 #, elixir-autogen, elixir-format
 msgid "must be numbers only"
 msgstr "debe contener número únicamente"
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:127
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:173
+#, elixir-autogen, elixir-format
+msgid "Ean"
+msgstr ""
+
+#: lib/price_spotter_web/live/admin/marketplaces/product_live/index.ex:129
+#, elixir-autogen, elixir-format
+msgid "Search by EAN"
+msgstr "Búsqueda por EAN"
+
+#: lib/price_spotter_web/components/core_components.ex:746
+#, elixir-autogen, elixir-format
+msgid "New"
+msgstr "Nuevo"

--- a/priv/repo/migrations/20240519061608_add_product_field_ean.exs
+++ b/priv/repo/migrations/20240519061608_add_product_field_ean.exs
@@ -1,0 +1,9 @@
+defmodule PriceSpotter.Repo.Migrations.AddProductFieldEan do
+  use Ecto.Migration
+
+  def change do
+    alter table(:products) do
+      add :ean, :string, default: nil
+    end
+  end
+end


### PR DESCRIPTION
This PR adds:

- Credo issue fix
- Update form background color
- Adds an ean field to the Product schema
- Add ean form errors to translations
- Add a product producer
- Add a hook to copy text via js
- Implement a component to render ean codes
- Add support to copy EAN codes on click
- Update product filters with ean
- Update some translations
- Add an ean filter
- Promotes ean with a 'new feature' pill
- Add support to copy eans by pressing the Enter key
- UI/UX improvements in Show product
- Update category to be optional for products
